### PR TITLE
Fix memory leaks on Android.

### DIFF
--- a/lib/src/treefortress/sound/SoundInstance.as
+++ b/lib/src/treefortress/sound/SoundInstance.as
@@ -325,12 +325,11 @@ package treefortress.sound
 					soundCompleted.dispatch(this);
 				}
 			}
-			//Clear out any old channels...
-			for(var i:int = oldChannels.length; i--;){
-				if(channel.position == sound.length){
-					stopChannel(channel);
-					oldChannels.splice(i, 1);
-				}
+			
+			stopChannel( channel );
+			var index:int = oldChannels.indexOf( channel );
+			if( index >= 0 ) {
+				oldChannels.splice( index, 1 );
 			}
 		}
 		


### PR DESCRIPTION
Stop channel regardless of its position inside onSoundComplete method. Channel position for some reason does not match the sound length on Android.
