### PR TITLE
SoundInstance destroy() bugfix

### DIFF
--- a/lib/src/treefortress/sound/SoundInstance.as
+++ b/lib/src/treefortress/sound/SoundInstance.as
@@ -293,7 +293,9 @@ package treefortress.sound
 			_soundTransform = null;
 			stopChannel(channel);
 			channel = null;
-			fade.end(false);
+
+			if ( fade )
+				fade.end(false);
 		}
 		
 		/**


### PR DESCRIPTION
the getter "fade()" is returning the field "currentTween". Which is null in any of my cases. As far as I can see this tween will be only set if u call fadeTo() or fadeFrom(), which I never do. So it always crashes when I call Destroy.

So here I check first if currentTween exists.

Cheers